### PR TITLE
Add toast support and product service

### DIFF
--- a/apps/admin/src/app.config.ts
+++ b/apps/admin/src/app.config.ts
@@ -8,7 +8,8 @@ import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { registerLocaleData } from '@angular/common';
 import localeTr from '@angular/common/locales/tr';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { errorInterceptor } from './interceptors/error.interceptor';
 
 registerLocaleData(localeTr); //belli şeyleri local diline getiriyor örneğin saat gösterimi..
 
@@ -17,6 +18,7 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
     provideHttpClient(),
+    { provide: HTTP_INTERCEPTORS, useValue: errorInterceptor, multi: true },
     provideRouter(appRoutes),
     { provide: LOCALE_ID, useValue: 'tr' },
   ],

--- a/apps/admin/src/app.routes.ts
+++ b/apps/admin/src/app.routes.ts
@@ -13,10 +13,18 @@ export const appRoutes: Route[] = [
         path: '',
         loadComponent: () => import('./pages/home/home'),
       },
-      {
-        path: 'products',
-        loadComponent: () => import('./pages/products/products'),
-      },
+        {
+          path: 'products',
+          loadComponent: () => import('./pages/products/products'),
+        },
+        {
+          path: 'products/create',
+          loadComponent: () => import('./pages/products/create/create'),
+        },
+        {
+          path: 'products/edit/:id',
+          loadComponent: () => import('./pages/products/edit/edit'),
+        },
     ],
   },
 ]; // Yani, /products gibi bir yol açıldığında önce layout yüklenir, sonra onun içinde products bileşeni gösterilir. Bu, ortak bir layout altında farklı içeriklerin gösterilmesini sağlar.

--- a/apps/admin/src/app.ts
+++ b/apps/admin/src/app.ts
@@ -4,11 +4,15 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import ToastContainer from './components/toast-container';
 
 @Component({
-  imports: [RouterModule],
+  imports: [RouterModule, ToastContainer],
   selector: 'app-root',
-  template: `<router-outlet />`,
+  template: `
+    <router-outlet />
+    <app-toast-container />
+  `,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/admin/src/components/toast-container.ts
+++ b/apps/admin/src/components/toast-container.ts
@@ -1,0 +1,50 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+  computed,
+  inject,
+} from '@angular/core';
+import { NgFor, NgClass } from '@angular/common';
+import { ToastService, ToastType } from '../services/toast.service';
+
+@Component({
+  selector: 'app-toast-container',
+  standalone: true,
+  imports: [NgFor, NgClass],
+  template: `
+    <div class="alert-top-right">
+      <div
+        *ngFor="let msg of messages()"
+        class="animated-alert"
+        [ngClass]="'custom-alert-' + msg.type"
+      >
+        <div class="custom-alert-content">
+          <div class="custom-alert-icon">
+            <span class="material-symbols-outlined">{{ icon(msg.type) }}</span>
+          </div>
+          <div class="custom-alert-text">{{ msg.text }}</div>
+        </div>
+      </div>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class ToastContainer {
+  readonly #service = inject(ToastService);
+  readonly messages = computed(() => this.#service.messages());
+
+  icon(type: ToastType) {
+    switch (type) {
+      case 'success':
+        return 'check_circle';
+      case 'warning':
+        return 'warning';
+      case 'danger':
+        return 'error';
+      default:
+        return 'info';
+    }
+  }
+}

--- a/apps/admin/src/interceptors/error.interceptor.ts
+++ b/apps/admin/src/interceptors/error.interceptor.ts
@@ -1,0 +1,14 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { ToastService } from '../services/toast.service';
+import { catchError, throwError } from 'rxjs';
+
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  const toast = inject(ToastService);
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      toast.show(error.message || 'HTTP Error', 'danger');
+      return throwError(() => error);
+    })
+  );
+};

--- a/apps/admin/src/pages/products/create/create.html
+++ b/apps/admin/src/pages/products/create/create.html
@@ -8,9 +8,9 @@
 <div class="row">
   <div class="col-md-4 col-12">
     <div class="card">
-      <div class="card-header">
-        <h4>{{title()}}</h4>
-      </div>
+<div class="card-header">
+  <h4>Add Product</h4>
+</div>
       <div class="card-body">
         <form #form="ngForm" autocomplete="off" (ngSubmit)="save(form)">
           <div class="form-group mt-2">
@@ -18,7 +18,7 @@
             <input
               type="text"
               class="form-control"
-              [(ngModel)]="data().name"
+              [(ngModel)]="model.name"
               name="name"
             />
           </div>
@@ -28,7 +28,7 @@
             <input
               type="text"
               class="form-control"
-              [(ngModel)]="data().imageUrl"
+              [(ngModel)]="model.imageUrl"
               name="imageUrl"
             />
           </div>
@@ -38,7 +38,7 @@
             <input
               type="text"
               class="form-control"
-              [(ngModel)]="data().price"
+              [(ngModel)]="model.price"
               name="price"
               mask="separator.2"
               thousandSeparator="."
@@ -50,13 +50,13 @@
             <input
               type="text"
               class="form-control"
-              [(ngModel)]="data().stock"
+              [(ngModel)]="model.stock"
               name="stock"
             />
           </div>
 
           <div class="form-group mt-2 d-flex justify-content-end">
-            <button type="submit" class="btn btn-primary">{{btnName()}}</button>
+            <button type="submit" class="btn btn-primary">Save</button>
           </div>
         </form>
       </div>

--- a/apps/admin/src/pages/products/create/create.ts
+++ b/apps/admin/src/pages/products/create/create.ts
@@ -1,5 +1,3 @@
-import { HttpClient } from '@angular/common/http';
-//import { Location } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -9,6 +7,7 @@ import {
 import { FormsModule, NgForm } from '@angular/forms';
 import { Router } from '@angular/router';
 import Blank from 'apps/admin/src/components/blank';
+import { ProductService } from '../../services/product.service';
 
 @Component({
   imports: [Blank, FormsModule],
@@ -17,18 +16,20 @@ import Blank from 'apps/admin/src/components/blank';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class Create {
-  readonly #http = inject(HttpClient);
   readonly #router = inject(Router);
-  //readonly #location = inject(Location);
+  readonly #service = inject(ProductService);
+
+  model = {
+    name: '',
+    imageUrl: '',
+    price: 0,
+    stock: 0,
+  };
 
   save(form: NgForm) {
     if (!form.valid) return;
 
-    this.#http
-      .post('http://localhost:3000/products', form.value)
-      .subscribe(() => {
-        this.#router.navigateByUrl('/products');
-        //this.#location.back(); //bir öncesi sayfaya işlem sonrası dönmeni sağlıyor
-      });
+    this.#service.create(this.model);
+    this.#router.navigateByUrl('/products');
   }
 }

--- a/apps/admin/src/pages/products/edit/edit.html
+++ b/apps/admin/src/pages/products/edit/edit.html
@@ -1,0 +1,39 @@
+<app-blank
+  pageTitle="Edit-Product"
+  [breadcrums]="[
+    {title: 'Products', url: '/products', icon: 'deployed_code'},
+    {title: 'Edit', url: '/products/edit', icon: 'edit'}]"
+/>
+
+<div class="row" *ngIf="data as d">
+  <div class="col-md-4 col-12">
+    <div class="card">
+      <div class="card-header">
+        <h4>Edit Product</h4>
+      </div>
+      <div class="card-body">
+        <form #form="ngForm" autocomplete="off" (ngSubmit)="save(form)">
+          <div class="form-group mt-2">
+            <label>Name</label>
+            <input type="text" class="form-control" [(ngModel)]="d.name" name="name" />
+          </div>
+          <div class="form-group mt-2">
+            <label>Image</label>
+            <input type="text" class="form-control" [(ngModel)]="d.imageUrl" name="imageUrl" />
+          </div>
+          <div class="form-group mt-2">
+            <label>Price</label>
+            <input type="text" class="form-control" [(ngModel)]="d.price" name="price" />
+          </div>
+          <div class="form-group mt-2">
+            <label>Stock</label>
+            <input type="text" class="form-control" [(ngModel)]="d.stock" name="stock" />
+          </div>
+          <div class="form-group mt-2 d-flex justify-content-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/admin/src/pages/products/edit/edit.ts
+++ b/apps/admin/src/pages/products/edit/edit.ts
@@ -1,0 +1,42 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+  ViewEncapsulation,
+} from '@angular/core';
+import { FormsModule, NgForm } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import Blank from 'apps/admin/src/components/blank';
+import { ProductService } from '../../services/product.service';
+import { ProductModel } from '../products';
+
+@Component({
+  standalone: true,
+  imports: [Blank, FormsModule],
+  templateUrl: './edit.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class Edit implements OnInit {
+  readonly #route = inject(ActivatedRoute);
+  readonly #router = inject(Router);
+  readonly #service = inject(ProductService);
+  readonly #http = inject(HttpClient);
+
+  data: ProductModel | null = null;
+
+  ngOnInit(): void {
+    const id = Number(this.#route.snapshot.paramMap.get('id'));
+    this.#http
+      .get<ProductModel>(`http://localhost:3000/products/${id}`)
+      .subscribe((p) => (this.data = p));
+  }
+
+  save(form: NgForm) {
+    if (!form.valid || !this.data) return;
+    this.#service.update(this.data);
+    this.#router.navigateByUrl('/products');
+  }
+}

--- a/apps/admin/src/pages/products/products.html
+++ b/apps/admin/src/pages/products/products.html
@@ -61,6 +61,7 @@
       title="Edit"
       style="margin-right: 10px"
       flexiTooltip
+      [routerLink]="['/products/edit', item.id]"
     ></flexi-button>
     <flexi-button
       btnIcon="delete"
@@ -68,6 +69,7 @@
       btnSize="small"
       title="Delete"
       flexiTooltip
+      (click)="delete(item)"
     ></flexi-button>
   </ng-template>
 </flexi-grid>

--- a/apps/admin/src/pages/products/products.ts
+++ b/apps/admin/src/pages/products/products.ts
@@ -1,14 +1,16 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
   ViewEncapsulation,
+  computed,
+  signal,
+  inject,
+  OnInit,
 } from '@angular/core';
 import Blank from '../../components/blank';
 import { FlexiGridFilterDataModel, FlexiGridModule } from 'flexi-grid';
-import { signal } from '@angular/core';
-import { httpResource } from '@angular/common/http';
 import { RouterLink } from '@angular/router';
+import { ProductService } from '../../services/product.service';
 
 export interface ProductModel {
   id: number;
@@ -26,12 +28,15 @@ export interface ProductModel {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export default class Products {
-  readonly result = httpResource<ProductModel[]>(
-    () => 'http://localhost:3000/products'
-  );
-  readonly data = computed(() => this.result.value() ?? []);
-  readonly loading = computed(() => this.result.isLoading());
+export default class Products implements OnInit {
+  readonly service = inject(ProductService);
+
+  ngOnInit() {
+    this.service.load();
+  }
+
+  readonly data = computed(() => this.service.products());
+  readonly loading = computed(() => false);
 
   readonly categoryFilter = signal<FlexiGridFilterDataModel[]>([
     {
@@ -39,4 +44,12 @@ export default class Products {
       value: 'Cell Phone',
     },
   ]);
+
+  edit(product: ProductModel) {
+    // navigate to edit page or open a modal
+  }
+
+  delete(product: ProductModel) {
+    this.service.remove(product.id);
+  }
 }

--- a/apps/admin/src/services/product.service.ts
+++ b/apps/admin/src/services/product.service.ts
@@ -1,0 +1,56 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject, signal } from '@angular/core';
+import { ProductModel } from '../pages/products/products';
+import { ToastService } from './toast.service';
+
+@Injectable({ providedIn: 'root' })
+export class ProductService {
+  private readonly http = inject(HttpClient);
+  private readonly toast = inject(ToastService);
+  readonly products = signal<ProductModel[]>([]);
+
+  load() {
+    this.http
+      .get<ProductModel[]>('http://localhost:3000/products')
+      .subscribe({
+        next: (p) => this.products.set(p),
+        error: () => this.toast.show('Failed to load products', 'danger'),
+      });
+  }
+
+  create(product: Omit<ProductModel, 'id'>) {
+    return this.http
+      .post<ProductModel>('http://localhost:3000/products', product)
+      .subscribe({
+        next: () => {
+          this.toast.show('Product created', 'success');
+          this.load();
+        },
+        error: () => this.toast.show('Create failed', 'danger'),
+      });
+  }
+
+  update(product: ProductModel) {
+    return this.http
+      .put(`http://localhost:3000/products/${product.id}`, product)
+      .subscribe({
+        next: () => {
+          this.toast.show('Product updated', 'success');
+          this.load();
+        },
+        error: () => this.toast.show('Update failed', 'danger'),
+      });
+  }
+
+  remove(id: number) {
+    return this.http
+      .delete(`http://localhost:3000/products/${id}`)
+      .subscribe({
+        next: () => {
+          this.toast.show('Product deleted', 'success');
+          this.load();
+        },
+        error: () => this.toast.show('Delete failed', 'danger'),
+      });
+  }
+}

--- a/apps/admin/src/services/toast.service.ts
+++ b/apps/admin/src/services/toast.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, signal } from '@angular/core';
+
+export type ToastType = 'primary' | 'success' | 'warning' | 'danger';
+export interface ToastMessage {
+  id: number;
+  text: string;
+  type: ToastType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private counter = 0;
+  readonly messages = signal<ToastMessage[]>([]);
+
+  show(text: string, type: ToastType = 'primary') {
+    const id = ++this.counter;
+    this.messages.update((msgs) => [...msgs, { id, text, type }]);
+    setTimeout(() => this.remove(id), 4000);
+  }
+
+  remove(id: number) {
+    this.messages.update((msgs) => msgs.filter((m) => m.id !== id));
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable ToastService and ToastContainer component
- wire toast container into the root app
- create ProductService with CRUD methods and toast notifications
- update product pages to use the service
- add edit page and routes
- show notifications for create/delete/update
- register HTTP interceptor for toast-based error messages

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_687f4e0abfe48328b9c9a21119bb99bd